### PR TITLE
Install dotnet SDK

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/dotnet:6.0
+FROM mcr.microsoft.com/devcontainers/dotnet:8.0
 
 # Install NodeJS
 # [Choice] Node.js version: none, lts/*, 18, 16, 14

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,11 +29,6 @@ RUN cd /home/vscode && mkdir azure-pipelines && cd azure-pipelines
 ARG ARCH="x64"
 ARG AGENT_VERSION="2.206.1"
 
-RUN cd /home/vscode/azure-pipelines \
-    && curl -O -L https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/vsts-agent-linux-${ARCH}-${AGENT_VERSION}.tar.gz \
-    && tar xzf /home/vscode/azure-pipelines/vsts-agent-linux-${ARCH}-${AGENT_VERSION}.tar.gz \
-    && /home/vscode/azure-pipelines/bin/installdependencies.sh
-
 # copy over the start.sh script
 COPY library-scripts/start.sh /home/vscode/azure-pipelines/start.sh
 

--- a/.devcontainer/library-scripts/start.sh
+++ b/.devcontainer/library-scripts/start.sh
@@ -3,6 +3,13 @@
 
 #Script modified from https://github.com/Pwd9000-ML/GitHub-Codespaces-Lab/tree/master/.devcontainer/codespaceADOagent
 
+if [! -f /home/vscode/azure-pipelines/vsts-agent-linux-${ARCH}-${AGENT_VERSION}.tar.gz]; then
+    echo "Downloading Azure Pipelines agent..."
+    curl -O -L https://vstsagentpackage.azureedge.net/agent/${AGENT_VERSION}/vsts-agent-linux-${ARCH}-${AGENT_VERSION}.tar.gz \
+    tar xzf /home/vscode/azure-pipelines/vsts-agent-linux-${ARCH}-${AGENT_VERSION}.tar.gz \
+    ./bin/installdependencies.sh
+fi
+
 #GitHub Codespace secrets
 ADO_ORG=$ADO_ORG
 ADO_PAT=$ADO_PAT


### PR DESCRIPTION
Previously running 'dotnet' in the bash shell resulted in a **command not found** error. This was due to a network error during the docker file setup.